### PR TITLE
`read.gct` function doesn't work with duplicated row-names

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -54,7 +54,14 @@ read.gct <- function(gct, ...) {
                 col.names = colNames,
                 row.names = NULL, header = FALSE,  ...)
 
-    rownames(t) <- t[,1]
+    rnms <- as.character(t[, 1])
+    if (anyDuplicated(rnms)){
+        warning("Row names in gct file were not unique. I will make them unique for you.")
+        rnms <- make.unique(rnms)
+    }
+
+    # rownames(t) <- t[,1]
+    rownames(t) <- rnms
 
     exp <- as.matrix(t[, (ann.row + 2):ncol(t)])
 


### PR DESCRIPTION
I've run into a problem with opening `gct` files in R using the `read.gct` function (files were exported from the Phantasus website). Phantasus tends to take some column values for row names. For instance, in the file I've attached, it chose the adjusted p-value column, resulting in non-unique row names and causing issues. To deal with that, I've made some adjustments to the read.gct function. Now, it doesn't crash anymore, but it does issue a warning.
[DE_GSE140187_LN_Tfh_vs_Naive.zip](https://github.com/ctlab/phantasus/files/14285841/DE_GSE140187_LN_Tfh_vs_Naive.zip)
