### PR TITLE
Remove dependency on SSL certificate

### DIFF
--- a/inst/configs/R/phantasus/user.conf
+++ b/inst/configs/R/phantasus/user.conf
@@ -8,8 +8,7 @@ default:
     geo_path: !expr file.path(cache_root, 'geo/')
     annot_db: !expr file.path(cache_root, 'annotationdb/')
     fgsea_pathways: !expr file.path(cache_root, 'fgsea_pathways/')
-    rnaseq_counts: "https://alserglab.wustl.edu/hsds/?domain=/counts"
+    rnaseq_counts: !expr file.path(cache_root, 'rnaseq_counts/')
   internal_ports: [8001, 8002, 8003, 8004, 8005, 8006, 8007, 8008, 8009, 8010]
   geo_mirrors:
     true_geo: "https://ftp.ncbi.nlm.nih.gov"
-    minimal_cache: "https://alserglab.wustl.edu/files/phantasus/minimal-cache/"


### PR DESCRIPTION
Update rnaseq_counts path to use local cache directory removing dependency on alserglab

to prevent
Error in curl::curl_fetch_memory(url, handle = handle) :
  SSL peer certificate or SSH remote key was not OK: [alserglab.wustl.edu] SSL certificate problem: self-signed certificate in certificate chain
Calls: <Anonymous> ... request_fetch -> request_fetch.write_memory -> <Anonymous>
Execution halted
Failed to complete setup! Bad configuration file or user: www-data doesn't have permissions to write cache or configuration file.